### PR TITLE
Added support for consolidated results archives

### DIFF
--- a/centinel/views.py
+++ b/centinel/views.py
@@ -6,6 +6,7 @@ import glob
 import json
 import os
 from werkzeug import secure_filename
+import tarfile
 
 from centinel.models import Client
 import config
@@ -70,6 +71,14 @@ def submit_result():
     file_path = os.path.join(config.results_dir, client_dir, file_name)
 
     result_file.save(file_path)
+
+    if tarfile.is_tarfile(file_path):
+        with tarfile.open(file_path, "r:bz2") as tar:
+            members = [tarinfo for tarinfo in tar
+                       if os.path.splitext(tarinfo.name)[1] == ".json"]
+            tar.extractall(os.path.join(config.results_dir, client_dir),
+                           members=members)
+        os.remove(file_path)
 
     return flask.jsonify({"status": "success"}), 201
 


### PR DESCRIPTION
This adds support on the server to receive and extract consolidated result files from clients in .tar.bz2 format (extract and then remove the tarball).
This is backward-compatible with normal .json result uploading.
