### PR TITLE
Baseline experimnents

### DIFF
--- a/centinel/views.py
+++ b/centinel/views.py
@@ -198,10 +198,6 @@ def get_user_specific_content(folder, filename=None, json_var=None):
             json.dump(freqs, file_p)
 
     files = {}
-    user_dir = os.path.join(folder, username, '*')
-    for path in glob.glob(user_dir):
-        file_name = os.path.basename(path)
-        files[file_name] = path
 
     # include country-specific baseline content
     country_specific_dir = os.path.join(folder, client.country)
@@ -234,6 +230,11 @@ def get_user_specific_content(folder, filename=None, json_var=None):
     else:
         print ("Global baseline folder \"%s\" "
                "doesn't exist!" %(global_dir))
+
+    user_dir = os.path.join(folder, username, '*')
+    for path in glob.glob(user_dir):
+        file_name = os.path.basename(path)
+        files[file_name] = path
 
     if filename is None:
         for filename in files:

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -176,10 +176,10 @@ def get_user_specific_content(folder, filename=None, json_var=None):
     # is requested.
     if (json_var == "experiments" and 
         (filename is None or filename == "scheduler.info")):
-        country_scheduler_filename = os.path.join(config.experiments_dir,
-                                                  client.country, "scheduler.info")
         global_scheduler_filename = os.path.join(config.experiments_dir,
                                                  "global", "scheduler.info")
+        country_scheduler_filename = os.path.join(config.experiments_dir,
+                                                  client.country, "scheduler.info")
         client_scheduler_filename = os.path.join(config.experiments_dir,
                                                  username, "scheduler.info")
 

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -176,22 +176,22 @@ def get_user_specific_content(folder, filename=None, json_var=None):
     # is requested.
     if (json_var == "experiments" and 
         (filename is None or filename == "scheduler.info")):
-        client_scheduler_filename = os.path.join(config.experiments_dir,
-                                                 username, "scheduler.info")
         country_scheduler_filename = os.path.join(config.experiments_dir,
                                                   client.country, "scheduler.info")
         global_scheduler_filename = os.path.join(config.experiments_dir,
                                                  "global", "scheduler.info")
+        client_scheduler_filename = os.path.join(config.experiments_dir,
+                                                 username, "scheduler.info")
 
         freqs = {}
-        if os.path.exists(client_scheduler_filename):
-            with open(client_scheduler_filename, 'r') as file_p:
-                freqs.update(json.load(file_p))
         if os.path.exists(country_scheduler_filename):
             with open(country_scheduler_filename, 'r') as file_p:
                 freqs.update(json.load(file_p))
         if os.path.exists(global_scheduler_filename):
             with open(global_scheduler_filename, 'r') as file_p:
+                freqs.update(json.load(file_p))
+        if os.path.exists(client_scheduler_filename):
+            with open(client_scheduler_filename, 'r') as file_p:
                 freqs.update(json.load(file_p))
 
         with open(client_scheduler_filename, 'w') as file_p:

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -184,11 +184,11 @@ def get_user_specific_content(folder, filename=None, json_var=None):
                                                  username, "scheduler.info")
 
         freqs = {}
-        if os.path.exists(country_scheduler_filename):
-            with open(country_scheduler_filename, 'r') as file_p:
-                freqs.update(json.load(file_p))
         if os.path.exists(global_scheduler_filename):
             with open(global_scheduler_filename, 'r') as file_p:
+                freqs.update(json.load(file_p))
+        if os.path.exists(country_scheduler_filename):
+            with open(country_scheduler_filename, 'r') as file_p:
                 freqs.update(json.load(file_p))
         if os.path.exists(client_scheduler_filename):
             with open(client_scheduler_filename, 'r') as file_p:
@@ -198,6 +198,21 @@ def get_user_specific_content(folder, filename=None, json_var=None):
             json.dump(freqs, file_p)
 
     files = {}
+
+    # include global baseline content
+    global_dir = os.path.join(folder, "global")
+    if os.path.exists(global_dir):
+        for path in glob.glob(os.path.join(global_dir, "*")):
+            file_name = os.path.basename(path)
+            # avoid sending the global scheduler here
+            # the only scheduler file sent must be the unified scheduler
+            # in the client's experiments dir.
+            if file_name == "scheduler.info":
+                continue
+            files[file_name] = path
+    else:
+        print ("Global baseline folder \"%s\" "
+               "doesn't exist!" %(global_dir))
 
     # include country-specific baseline content
     country_specific_dir = os.path.join(folder, client.country)
@@ -215,21 +230,6 @@ def get_user_specific_content(folder, filename=None, json_var=None):
     else:
         print ("Country baseline folder %s "
                "doesn't exist!" %(country_specific_dir))
-
-    # include global baseline content
-    global_dir = os.path.join(folder, "global")
-    if os.path.exists(global_dir):
-        for path in glob.glob(os.path.join(global_dir, "*")):
-            file_name = os.path.basename(path)
-            # avoid sending the global scheduler here
-            # the only scheduler file sent must be the unified scheduler
-            # in the client's experiments dir.
-            if file_name == "scheduler.info":
-                continue
-            files[file_name] = path
-    else:
-        print ("Global baseline folder \"%s\" "
-               "doesn't exist!" %(global_dir))
 
     user_dir = os.path.join(folder, username, '*')
     for path in glob.glob(user_dir):

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -171,17 +171,76 @@ def get_user_specific_content(folder, filename=None, json_var=None):
     if not client.has_given_consent:
         flask.abort(418)
 
+    # all of the scheduler files are combined together here.
+    # this is run every time the experiment list or "scheduler.info"
+    # is requested.
+    if (json_var == "experiments" and 
+        (filename is None or filename == "scheduler.info")):
+        client_scheduler_filename = os.path.join(config.experiments_dir,
+                                                 username, "scheduler.info")
+        country_scheduler_filename = os.path.join(config.experiments_dir,
+                                                  client.country, "scheduler.info")
+        global_scheduler_filename = os.path.join(config.experiments_dir,
+                                                 "global", "scheduler.info")
+
+        freqs = {}
+        if os.path.exists(client_scheduler_filename):
+            with open(client_scheduler_filename, 'r') as file_p:
+                freqs.update(json.load(file_p))
+        if os.path.exists(country_scheduler_filename):
+            with open(country_scheduler_filename, 'r') as file_p:
+                freqs.update(json.load(file_p))
+        if os.path.exists(global_scheduler_filename):
+            with open(global_scheduler_filename, 'r') as file_p:
+                freqs.update(json.load(file_p))
+
+        with open(client_scheduler_filename, 'w') as file_p:
+            json.dump(freqs, file_p)
+
     files = {}
     user_dir = os.path.join(folder, username, '*')
     for path in glob.glob(user_dir):
         file_name = os.path.basename(path)
         files[file_name] = path
 
+    # include country-specific baseline content
+    country_specific_dir = os.path.join(folder, client.country)
+    if os.path.exists(country_specific_dir):
+        # if baseline experiments exist for this country (==folder exists),
+        # sync up all of the files in that dir.
+        for path in glob.glob(os.path.join(country_specific_dir, "*")):
+            file_name = os.path.basename(path)
+            # avoid sending the country-specific scheduler here
+            # the only scheduler file sent must be the unified scheduler
+            # in the client's experiments dir.
+            if file_name == "scheduler.info":
+                continue
+            files[file_name] = path
+    else:
+        print ("Country baseline folder %s "
+               "doesn't exist!" %(country_specific_dir))
+
+    # include global baseline content
+    global_dir = os.path.join(folder, "global")
+    if os.path.exists(global_dir):
+        for path in glob.glob(os.path.join(global_dir, "*")):
+            file_name = os.path.basename(path)
+            # avoid sending the global scheduler here
+            # the only scheduler file sent must be the unified scheduler
+            # in the client's experiments dir.
+            if file_name == "scheduler.info":
+                continue
+            files[file_name] = path
+    else:
+        print ("Global baseline folder \"%s\" "
+               "doesn't exist!" %(global_dir))
+
     if filename is None:
         for filename in files:
             with open(files[filename], 'r') as file_p:
                 hash_val = hashlib.md5(file_p.read()).digest()
                 files[filename] = urlsafe_b64encode(hash_val)
+
         return flask.jsonify({json_var: files})
 
     # this should never happen, but better be safe

--- a/list_grabber.py
+++ b/list_grabber.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+#
+# Abbas Razaghpanah (arazaghpanah@cs.stonybrook.edu)
+# January 2015, Stony Brook University
+#
+# list_grabber.py: a script to hit a given URL and download
+# all of the csv files linked on the index page.
+# This can be run periodically to update URL lists for different 
+# countries, censorship products, etc. using a URL repository.
+# The script assumes HTTP basic authentication for the repository.
+#
+# For CSV files that are of form XX.csv, it is assumed that it
+# belongs to a country XX and it will be copied to the related
+# directory (which is created if it doesn't exist). Everything
+# else will go to "global".
+
+import argparse
+import os
+from os import path
+import re
+import requests
+from requests.auth import HTTPDigestAuth
+import string
+from urlparse import urljoin
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    url_help = ('The URL for the index page. All of the file names from '
+                'hyperlinks will be joined with this URL.')
+    parser.add_argument('--url', '-U', help=url_help, required=True)
+
+    user_help = ('Username and password for HTTP authentication. '
+                 'It should be provided as username:password')
+    parser.add_argument('--user', '-u', help=user_help, default=None)
+
+    output_help = ('The output directory where the files are supposed to be '
+                   'saved to. Defaults to current directory.')
+    parser.add_argument('--output', '-o', help=output_help, default='.')
+
+    digest_help = ('Enable HTTP digest authentication. If username and password '
+                   'are provided, basic authentication is used as default.')
+    parser.add_argument('--digest', '-d', help=digest_help, dest='digest', action='store_true')
+    parser.set_defaults(digest=False)
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.output):
+        parser.error("The output directory \"%s\" does not exist!" %(args.output))
+
+    if args.user is None and args.digest is False:
+        parser.error('Digest authentication has been enabled but no username and password '
+                     'given.')
+    return args
+
+if __name__ == "__main__":
+
+    print "Downloading list index."
+    args = parse_args()
+    url = args.url
+    if args.user is not None:
+        user, password = args.user.split(':')
+        if args.digest == True:
+            auth = HTTPDigestAuth(user,password)
+        else:
+            auth = (user, password)
+    else:
+        auth = None
+
+
+    directory = os.path.join(args.output, "global")
+    req = requests.get(url, auth=auth)
+    req.raise_for_status()
+    csvs = re.findall('href=\"([^\'\.\"]+\.csv)\"', req.text)
+
+    if not os.path.exists(directory):
+        print "Creating \"global\" directory at %s." %(directory)
+        os.makedirs(directory)
+
+    for csvfile in csvs:
+        path = urljoin(url, csvfile)
+        print "Downloading  list \"%s\"." %(path)
+        try:
+            req = requests.get(path, auth=auth)
+            req.raise_for_status()
+        except Exception as exp:
+            print "Error downloading file \"%s\": %s" %(path, exp)
+            continue
+
+        path = os.path.join(args.output, "global", csvfile)
+
+        # find out if it is a country-specific list
+        base = os.path.splitext(csvfile)[0].upper()
+        if len(base) == 2:
+            directory = os.path.join(args.output, base)
+            if not os.path.exists(directory):
+                print "Creating directory for country %s at %s." %(base, directory)
+                os.makedirs(directory)
+            path = os.path.join(directory, "country_list.csv")
+
+        output = open(path, 'w')
+        output.write(req.text)
+        output.close()

--- a/list_grabber.py
+++ b/list_grabber.py
@@ -60,7 +60,6 @@ def parse_args():
 
 if __name__ == "__main__":
 
-    print "Downloading list index."
     args = parse_args()
     url = args.url
     if args.user is not None:
@@ -75,6 +74,7 @@ if __name__ == "__main__":
 
     directory = os.path.join(args.output, "global")
     req = requests.get(url, auth=auth)
+    print "Downloading list index."
     req.raise_for_status()
     csvs = re.findall('href=\"([^\'\.\"]+\.csv)\"', req.text)
 

--- a/list_grabber.py
+++ b/list_grabber.py
@@ -14,14 +14,18 @@
 # directory (which is created if it doesn't exist). Everything
 # else will go to "global".
 
+
 import argparse
 import os
-from os import path
 import re
 import requests
-from requests.auth import HTTPDigestAuth
 import string
+
+
+from os import path
+from requests.auth import HTTPDigestAuth
 from urlparse import urljoin
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -52,6 +56,7 @@ def parse_args():
         parser.error('Digest authentication has been enabled but no username and password '
                      'given.')
     return args
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Added server-side support for baseline experiments. This includes directory sync for country-specific as well as global experiments, experiment input files, and scheduler files.
Also implemented a CSV list grabber to update the list of URLs periodically. The URL grabber downloads all of the CSV files from links inside an index page and places them in appropriate directories on the server. These CSV files will serve as input files for baseline experiments.

@ben-jones, please review.