### PR TITLE
give more space to password hash in database

### DIFF
--- a/centinel/models.py
+++ b/centinel/models.py
@@ -22,7 +22,7 @@ class Client(db.Model):
     __tablename__ = 'clients'
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(36), index=True)  # uuid length=36
-    password_hash = db.Column(db.String(119))
+    password_hash = db.Column(db.String(130))
     last_ip = db.Column(db.String(IP_ADDR_LEN))
     last_seen = db.Column(db.DateTime)
     registered_date = db.Column(db.DateTime)


### PR DESCRIPTION
When migrating to PostgreSQL, I noticed that often password hash values ended up being larger than 119 characters and therefore were rejected. Increasing field length fixes that problem.\\
@ben-jones, please review.