### PR TITLE
Better VPN client support

### DIFF
--- a/centinel/models.py
+++ b/centinel/models.py
@@ -44,7 +44,8 @@ class Client(db.Model):
         # custom functionality. Also do type checking on the variable
         # type
 
-        allowed_keys = {"username": "string", "is_vpn": bool,
+        allowed_keys = {"username": "string",
+                        "is_vpn": bool,
                         "registered_date": datetime,
                         "last_seen": datetime,
                         "has_given_consent": bool,
@@ -73,7 +74,6 @@ class Client(db.Model):
             if "/" not in ip:
                 ip = ".".join(ip.split(".")[:3]) + ".0/24"
             self.last_ip = ip
-            self.is_vpn = kwargs.get('vpn')
         if 'consent' in kwargs:
             self.date_given_consent = datetime.now()
         country = kwargs.get('country')

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -345,7 +345,15 @@ def register():
     client_json['last_seen'] = datetime.now()
     client_json['registered_date'] = datetime.now()
     client_json['has_given_consent'] = False
-    client_json['is_vpn'] = False
+
+    # a VPN client does not need to give consent
+    if client_json.get('is_vpn'):
+        client_json['is_vpn'] = True
+        client_json['has_given_consent'] = True
+        client_json['date_given_consent'] = datetime.now()
+    else:
+        client_json['is_vpn'] = False
+
     client_json['roles'] = ['client']
 
     if not username or not password:


### PR DESCRIPTION
This waives consent process for VPN registration and properly sets the VPN flag in database.
Additionally, the VPN clients can set their country explicitly (for easier experiment fetching and display purposes) and their country will not change unless they change it themselves.
@ben-jones, please review.