### PR TITLE
support werkzeug 0.10.x and python 2.7.9 (backward-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,11 @@ Install psycopg2:
 
     $ pip install -U psycopg2
 
-#### Debian
-    $ apt-get install python-flask python-passlib python-flask-httpauth python-flask-sqlalchemy
-    $ pip install geoip2
-    $ python run.py
 
-#### OSX
-    $ pip install flask flask-httpauth flask-sqlalchemy passlib geoip2
+It is recommended that you run Python version > 2.7.9 and Werkzeug version >= 0.10.0 for better TLS support.
+
+#### Debian & OS X
+    $ pip install flask flask-httpauth flask-sqlalchemy passlib geoip2 netaddr postgres
     $ python run.py
 
 ### Supported platforms

--- a/run.py
+++ b/run.py
@@ -58,4 +58,4 @@ if __name__ == "__main__":
     # Also, I shouldn't have to say this, but *DO NOT COMMIT THE
     # KEY*. Under no circumstances should the key be committed
     app.run(host="0.0.0.0", port=8082, debug=True,
-            ssl_context=context)
+            ssl_context=context, threaded=True)

--- a/run.py
+++ b/run.py
@@ -9,7 +9,7 @@ if (2,7,9) > sys.version_info:
     print ("WARNING: Python is older than 2.7.9, "
            "using older SSL version. This is "
            "incompatible with Werkzeug 0.10.x and "
-           "will break if you use Werkzeug > 0.9.x")
+           "will break if you use Werkzeug >= 0.10.0")
     from OpenSSL import SSL
     py_279 = False
 else:

--- a/run.py
+++ b/run.py
@@ -3,7 +3,19 @@ import centinel
 import centinel.models
 import centinel.views
 import config
-from OpenSSL import SSL
+
+import sys
+if (2,7,9) > sys.version_info:
+    print ("WARNING: Python is older than 2.7.9, "
+           "using older SSL version. This is "
+           "incompatible with Werkzeug 0.10.x and "
+           "will break if you use Werkzeug > 0.9.x")
+    from OpenSSL import SSL
+    py_279 = False
+else:
+    import ssl
+    py_279 = True
+
 import os
 
 def parse_args():
@@ -33,9 +45,14 @@ if __name__ == "__main__":
         context='adhoc'
     else:
         # default method should be TLS
-        context = SSL.Context(SSL.TLSv1_METHOD)
-        context.use_privatekey_file(config.ssl_key)
-        context.use_certificate_file(config.ssl_cert)
+        if py_279:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            context.load_cert_chain(config.ssl_cert, config.ssl_key)
+        else:
+            context = SSL.Context(SSL.TLSv1_METHOD)
+            context.use_privatekey_file(config.ssl_key)
+            context.use_certificate_file(config.ssl_cert)
+
         context.load_verify_locations(config.ssl_chain)
 
     # Also, I shouldn't have to say this, but *DO NOT COMMIT THE


### PR DESCRIPTION
This enables TLSv1.2 and the newer SSL library included in 2.7.9. This improves security.
It is backward-compatible and one still can use the older versions (e.g. Python 2.7.6 and Werkzeug 0.9.x, but it will be less secure).
@ben-jones, please review.