### PR TITLE
Add remove client option

### DIFF
--- a/centinel/models.py
+++ b/centinel/models.py
@@ -30,6 +30,7 @@ class Client(db.Model):
     date_given_consent = db.Column(db.DateTime)
     typeable_handle = db.Column(db.String(8))
     is_vpn = db.Column(db.Boolean)
+    dont_display = db.Column(db.Boolean)
     country = db.Column(db.String(COUNTRY_CODE_LEN))
 
     # since a user can have multiple roles, we have a table to hold
@@ -44,6 +45,7 @@ class Client(db.Model):
         # custom functionality. Also do type checking on the variable
         # type
 
+        dont_display = False
         allowed_keys = {"username": "string",
                         "is_vpn": bool,
                         "registered_date": datetime,

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -326,12 +326,17 @@ def get_system_status():
     doesn't reveal anything important (e.g. IP address, username, etc.).
     The list is shuffled each time so that numbers are randomly assigned.
 
+    Note: we don't display clients who have the dont_display column set to 1/True
+
     """
     clients = Client.query.all()
     random.shuffle(clients)
     results = []
     number = 0
     for client in clients:
+        # dont add clients who have asked not to be displayed
+        if client.dont_display:
+            continue
         info = {}
         info['num'] = number
         info['country'] = client.country

--- a/config.py
+++ b/config.py
@@ -7,8 +7,8 @@ recommended_version = 1.1
 
 # user details
 current_user    = getpass.getuser()
-centinel_home   = os.path.join(os.path.expanduser('~'+current_user),
-                               '.centinel')
+centinel_home   = "/opt/centinel-server/"
+
 
 # directory structure
 results_dir     = os.path.join(centinel_home, 'results')

--- a/run.py
+++ b/run.py
@@ -29,6 +29,11 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
+    # create the centinel directory if it doesn't exist
+    if not os.path.exists(config.centinel_home):
+        os.makedirs(config.centinel_home)
+        print "Created centinel home directory at {}".format(config.centinel_home)
+
     db = centinel.db
     app = centinel.app
 


### PR DESCRIPTION
This pull requests adds two features
1) add a flag in the client db to not display the client and
2) moved centinel-server directory to /opt

I bundled these two together because I want to do a single server migration to WSGI.

@rpanah, would you please review this?