### PR TITLE
Fix auth issue

### DIFF
--- a/centinel/views.py
+++ b/centinel/views.py
@@ -666,5 +666,11 @@ def update_informed_consent():
 
 @auth.verify_password
 def verify_password(username, password):
+    if (len(username) == 0) and (len(password) == 0):
+        logging.warning(("Username and password are both empty. Are you sure "
+                         "that you enabled the WSGI option for HTTP "
+                         "authentication?\n"
+                         "Add WSGIPassAuthorization On to your WSGI config "
+                         "file under enabled-sites in Apache"))
     user = Client.query.filter_by(username=username).first()
     return user and user.verify_password(password)

--- a/misc/centinel.conf
+++ b/misc/centinel.conf
@@ -4,6 +4,7 @@
     WSGIDaemonProcess centinel-server threads=8
 #    WSGIProcessGroup centinel-server
     WSGIScriptAlias / /opt/centinel-server/code/centinel-server.wsgi
+    WSGIPassAuthorization On
 
     SSLEngine on
     SSLCertificateFile /opt/certs/server_iclab_org/41830e8b51ce6.crt


### PR DESCRIPTION
After running WSGI and centinel together for a day, I discovered that WSGI doesn't let you do HTTP authentication by default. This means that our password verification was being passed an empty username and password, so no one could authenticate.

This pull request adds that flag to our WSGI config and descriptive logging should the problem reappear. This is currently running on the ICLab server.

@rpanah, would you please review?