### PR TITLE
fixed the static content addressing issue

### DIFF
--- a/centinel/views.py
+++ b/centinel/views.py
@@ -557,12 +557,14 @@ def get_initial_informed_consent_with_handle(typeable_handle):
     if client.has_given_consent:
         return "Consent already given."
     username = client.username
+
     if config.prefetch_freedomhouse:
-        return display_consent_page(username,
-                                    'static/initial_informed_consent.html')
+        page_path = os.path.join(config.centinel_home,'static','initial_informed_consent.html')
     else:
-        return display_consent_page(username,
-                                    'static/no_prefetch_informed_consent.html')
+        page_path = os.path.join(config.centinel_home,'static','no_prefetch_informed_consent.html')
+
+    return display_consent_page(username,
+                                page_path)
 
 
 @app.route("/get_initial_consent")
@@ -577,7 +579,7 @@ def get_initial_informed_consent():
     if client.has_given_consent:
         return "Consent already given."
     return display_consent_page(username,
-                                'static/initial_informed_consent.html')
+                                os.path.join(config.centinel_home,'static','initial_informed_consent.html'))
 
 
 @app.route("/get_informed_consent_for_country")
@@ -599,12 +601,12 @@ def get_country_specific_consent():
     # if we don't already have the content from freedom house, fetch
     # it, then host it locally and insert it into the report
     freedom_url = "".join(["freedom_house_", country, ".html"])
-    filename = os.path.join("static", freedom_url)
+    filename = os.path.join(config.centinel_home, "static", freedom_url)
     # get the content from freedom house if we don't already have it
     get_page_and_strip_bad_content(constants.freedom_house_url(country),
                                    filename)
 
-    page_path = 'static/informed_consent.html'
+    page_path = os.path.join(centinel_home,'static','informed_consent.html')
     page_content = display_consent_page(username, page_path, freedom_url)
 
     flask.url_for('static', filename=freedom_url)

--- a/centinel/views.py
+++ b/centinel/views.py
@@ -546,6 +546,13 @@ def display_consent_page(username, path, freedom_url=''):
                                             u'static/' + freedom_url)
     return initial_page
 
+@app.route("/static/<filename>")
+def static_resource(filename):
+    file_path = os.path.join(config.centinel_home, 'static', filename)
+    if os.path.isfile(os.path.join(file_path)) and (filename in config.static_files_allowed):
+        return flask.send_from_directory(os.path.join(config.centinel_home, 'static'), filename)
+    else:
+        flask.abort(404)
 
 @app.route("/consent/<typeable_handle>")
 def get_initial_informed_consent_with_handle(typeable_handle):

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ centinel_home = "/opt/centinel-server/"
 results_dir     = os.path.join(centinel_home, 'results')
 experiments_dir = os.path.join(centinel_home, 'experiments')
 inputs_dir = os.path.join(centinel_home, 'inputs')
+static_files_allowed = ['economistDemocracyIndex.pdf', 'consent.js']
 
 # details for how to access the database
 def load_uri_from_file(filename):

--- a/static/no_prefetch_informed_consent.html
+++ b/static/no_prefetch_informed_consent.html
@@ -249,7 +249,7 @@
             <p class="list-group-item-text">Economist - Democracy
             Index:</p>
 
-            <p><a href="static/economistDemocracyIndex.pdf">Link to
+            <p><a href="/static/economistDemocracyIndex.pdf">Link to
             PDF</a></p>
 
             <p class="list-group-item-text">The research team will
@@ -399,7 +399,7 @@
             "replace-with-username-value">
           </form>
         </div>
-      </div><script src="static/consent.js" type="text/javascript">
+      </div><script src="/static/consent.js" type="text/javascript">
 </script> <script type="text/javascript">
 this.Consent()
       </script>


### PR DESCRIPTION
This should address the issue opened [here](https://github.com/iclab/centinel/issues/152), which made it impossible to give consent for clients. Since we're using WSGI now, the static content can no longer be addressed relative to the Python file. Creating a symlink to where the static content is under `config.centinel_home` makes this solution work properly.

@ben-jones, please review.